### PR TITLE
Fix sticky section headers not working

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -295,7 +295,7 @@ body {
     background: white;
     border-radius: 20px;
     margin-bottom: 20px;
-    overflow: hidden;
+    overflow: clip;
     box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
     transition: transform 0.3s;
 }
@@ -797,7 +797,7 @@ body {
 /* ======================================= */
 /* STICKY BOOK HEADER                      */
 /* ======================================= */
-.book-section.expanded .book-header {
+.book-header {
     position: sticky;
     top: 0;
     z-index: 10;


### PR DESCRIPTION
## Summary
- Fix `overflow: hidden` → `overflow: clip` on `.book-section` — `hidden` creates a scroll container that prevents `position: sticky` from working; `clip` clips content for rounded corners without breaking sticky
- Apply sticky positioning to all `.book-header` elements (not just expanded) so each section header sticks at the top and naturally gets pushed off by the next section

## Test plan
- [ ] Open any section — header sticks at top of viewport while scrolling through scriptures
- [ ] Scroll past the last scripture in a section — the next section's header pushes the previous one off
- [ ] Collapsed sections still display correctly with rounded corners

🤖 Generated with [Claude Code](https://claude.com/claude-code)